### PR TITLE
Nullable field-types support

### DIFF
--- a/lib/clickhouse/connection/query/result_set.rb
+++ b/lib/clickhouse/connection/query/result_set.rb
@@ -47,25 +47,25 @@ module Clickhouse
         end
 
         def parse_value(type, value)
-          if value
-            case type
-            when "UInt8", "UInt16", "UInt32", "UInt64", "Int8", "Int16", "Int32", "Int64"
-              parse_int_value value
-            when "Float32", "Float64"
-              parse_float_value value
-            when "String", "Enum8", "Enum16"
-              parse_string_value value
-            when /FixedString\(\d+\)/
-              parse_fixed_string_value value
-            when "Date"
-              parse_date_value value
-            when "DateTime"
-              parse_date_time_value value
-            when /Array\(/
-              parse_array_value value
-            else
-              raise NotImplementedError, "Cannot parse value of type #{type.inspect}"
-            end
+          case type
+          when "UInt8", "UInt16", "UInt32", "UInt64", "Int8", "Int16", "Int32", "Int64"
+            parse_int_value value
+          when "Nullable(UInt8)", "Nullable(UInt16)", "Nullable(UInt32)", "Nullable(UInt64)", "Nullable(Int8)", "Nullable(Int16)", "Nullable(Int32)",  "Nullable(Int64)"
+            parse_int_value value
+          when "Float32", "Float64", "Nullable(Float64)", "Nullable(Float32)"
+            parse_float_value value
+          when "String", "Enum8", "Enum16", "Nullable(String)"
+            parse_string_value value
+          when /FixedString\(\d+\)/
+            parse_fixed_string_value value
+          when "Date", "Nullable(Date)"
+            parse_date_value value
+          when "DateTime", "Nullable(DateTime)"
+            parse_date_time_value value
+          when /Array\(/
+            parse_array_value value
+          else
+            raise NotImplementedError, "Cannot parse value of type #{type.inspect}"
           end
         end
 
@@ -78,19 +78,19 @@ module Clickhouse
         end
 
         def parse_string_value(value)
-          value.force_encoding("UTF-8")
+          value.to_s.force_encoding("UTF-8")
         end
 
         def parse_fixed_string_value(value)
-          value.delete("\000").force_encoding("UTF-8")
+          value.to_s.delete("\000").force_encoding("UTF-8")
         end
 
         def parse_date_value(value)
-          Date.parse(value)
+          Date.parse(value) rescue nil # "rescue nil" for Nullable
         end
 
         def parse_date_time_value(value)
-          Time.parse(value)
+          Time.parse(value) rescue nil # "rescue nil" for Nullable
         end
 
         def parse_array_value(value)

--- a/test/unit/connection/query/test_result_set.rb
+++ b/test/unit/connection/query/test_result_set.rb
@@ -188,6 +188,115 @@ module Unit
               end
             end
           end
+
+          describe 'Nullable Integer' do
+            before do
+              @result_set = Clickhouse::Connection::Query::ResultSet.new(
+                  [
+                      [nil, nil, nil, nil, nil, nil, nil],
+                      [1, 1, 1, 1, 1, 1, 1]
+                  ],
+                  [
+                      "column_uint8",
+                      "column_uint16",
+                      "column_uint32",
+                      "column_uint64",
+                      "column_int8",
+                      "column_int16",
+                      "column_int32",
+                      "column_int64"
+                  ],
+                  [
+                      "Nullable(UInt8)",
+                      "Nullable(UInt16)",
+                      "Nullable(UInt32)",
+                      "Nullable(UInt64)",
+                      "Nullable(Int8)",
+                      "Nullable(Int16)",
+                      "Nullable(Int32)",
+                      "Nullable(Int64)"
+                  ]
+              )
+            end
+
+            it 'should parse as Integer' do
+              assert_equal [[0, 0, 0, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1, 1]],
+                           @result_set.to_a
+            end
+          end
+
+          describe 'Nullable Float' do
+            before do
+              @result_set = Clickhouse::Connection::Query::ResultSet.new(
+                  [
+                      [nil, nil],
+                      [1, 1]
+                  ],
+                  [
+                      "column_nullable_float64",
+                      "column_nullable_float32"
+                  ],
+                  [
+                      "Nullable(Float64)",
+                      "Nullable(Float32)"
+                  ]
+              )
+            end
+
+            it 'should parse as Float' do
+              assert_equal ["0.0", "0.0", "1.0", "1.0"],
+                           @result_set.flatten.map(&:inspect)
+            end
+          end
+
+          describe 'Nullable String' do
+            before do
+              @result_set = Clickhouse::Connection::Query::ResultSet.new(
+                  [
+                      [nil, nil],
+                      ['', ''],
+                      ['text', 'T']
+                  ],
+                  [
+                      "column_nullable_string",
+                      "column_fixed_string_1"
+                  ],
+                  [
+                      "Nullable(String)",
+                      "Nullable(FixedString(1))"
+                  ]
+              )
+            end
+
+            it 'should parse as String' do
+              assert_equal [["", ""], ["", ""], ["text", "T"]],
+                           @result_set.to_a
+            end
+          end
+
+          describe 'Nullable DateTime' do
+            before do
+              @result_set = Clickhouse::Connection::Query::ResultSet.new(
+                  [
+                      [nil, nil],
+                      ["2016-03-20", "2016-03-20 22:55:39"]
+                  ],
+                  [
+                      "column_nullable_date",
+                      "column_date_time"
+                  ],
+                  [
+                      "Nullable(Date)",
+                      "Nullable(DateTime)"
+                  ]
+              )
+            end
+
+            it 'should parse as Date/DateTime' do
+              assert_equal [[nil, nil], [Date.new(2016, 3, 20), Time.new(2016, 3, 20, 22, 55, 39)]],
+                           @result_set.to_a
+            end
+          end
         end
 
       end


### PR DESCRIPTION
Official documentation does not describes this feature.

Some documentation can be found at [ClickHouse/doc/example_datasets/nyc_taxi.md
](https://github.com/yandex/ClickHouse/blob/933313aea3d4fa1c217e4191b005055cf6caad0a/doc/example_datasets/nyc_taxi.md)

In this PR I skipped **Enum8** and **Enum16**, don't sure if they can be Nullable.

fixes #5