### PR TITLE
quote `event` as string argument in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Clickhouse.connection.exists_table("events")
 Insert data.
 
 ```ruby
-Clickhouse.connection.insert_rows(events, :names => %w(id year date time event user_id revenue)) do |rows|
+Clickhouse.connection.insert_rows("events", :names => %w(id year date time event user_id revenue)) do |rows|
   rows << [
     "d91d1c90",
     2016,


### PR DESCRIPTION
Just fixed.
without this fix, that sample code alerted as

```
NameError: undefined local variable or method `events' for main:Object
````