### PR TITLE
Pass options to Faraday client

### DIFF
--- a/lib/clickhouse/connection/client.rb
+++ b/lib/clickhouse/connection/client.rb
@@ -36,8 +36,8 @@ module Clickhouse
 
     private
 
-      def client
-        @client ||= Faraday.new(:url => url)
+      def client(options = {})
+        @client ||= Faraday.new(:url => url, :options => options)
       end
 
       def ensure_authentication


### PR DESCRIPTION
For example, this will allow to setup SSL certificate.